### PR TITLE
Use shared history subscription

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,26 @@ const App = () => {
 };
 ```
 
+#### Router.useRoutes
+
+Listen and match a bunch of your routes. Returns an array of routes, sorted by ascending specificity. Useful for route hierarchical representation (e.g. a breadcrumb component).
+
+```tsx
+import { match } from "ts-pattern";
+
+const Breadcrumbs = () => {
+  const routes = Router.useRoutes(["root", "users", "user"]);
+
+  return routes.map((route) => {
+    return match(route)
+      .with({ name: "root" }, () => "Home")
+      .with({ name: "users" }, () => "Users")
+      .with({ name: "user" }, ({ params: { userId } }) => userId)
+      .otherwise(() => null);
+  });
+};
+```
+
 #### Router.useLink
 
 As this library doesn't provide a single component, we expose this hook to create your own customized `Link`.

--- a/README.md
+++ b/README.md
@@ -281,6 +281,24 @@ const App = () => {
 };
 ```
 
+#### Router.useRouteFocus
+
+Registers a component as a route container, so that the element receives focus on route change. When using nested routes, the deepest route container is focused.
+
+```tsx
+const App = () => {
+  const route = Router.useRoute(["root", "users", "user"]);
+  const containerRef = React.useRef(null);
+
+  Router.useRouteFocus({
+    containerRef,
+    route,
+  });
+
+  <div ref={containerRef}>{/* match your route here*/}</div>;
+};
+```
+
 #### Router.subscribe
 
 Subscribe to location changes. Useful to reset keyboard focus.
@@ -341,7 +359,6 @@ decodeSearch("?invitation=542022247745&users=frank&users=chris");
 - Improve documentation
 - Tests, tests, tests
 - Switch to `useSyncExternalStore` (React 18+)
-- Write a "focus reset" recipe
 - Find a cool logo
 - Create a website (?)
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ const Router = createRouter(
 
 #### 👇 Note: All the following examples will use this `Router` instance.
 
-#### Router.location
+#### Router.getLocation
 
 ```tsx
 type Location = {
@@ -146,7 +146,7 @@ type Location = {
   hash?: string;
 };
 
-Router.location; // Location
+Router.getLocation(); // Location
 ```
 
 #### Router.navigate
@@ -327,7 +327,7 @@ const Redirect = ({ to }: { to: string }) => {
 Encode and decode url search parameters.
 
 ```tsx
-import { encodeSearch, decodeSearch } from "react-chicane";
+import { decodeSearch, encodeSearch } from "react-chicane";
 
 encodeSearch({ invitation: "542022247745", users: ["frank", "chris"] });
 // -> "?invitation=542022247745&users=frank&users=chris"

--- a/__tests__/router.tsx
+++ b/__tests__/router.tsx
@@ -1,0 +1,127 @@
+import * as React from "react";
+import * as ReactDOM from "react-dom";
+import { act } from "react-dom/test-utils";
+import { createRouter } from "../src";
+
+const routes = {
+  home: "/",
+  profile: "/profile/:username",
+} as const;
+
+const { useRoute, unsafeNavigate, getLocation, useRouteFocus } =
+  createRouter(routes);
+
+export type RouteName = keyof typeof routes;
+
+const routesToMatch: RouteName[] = ["home", "profile"];
+
+describe("router", () => {
+  let container;
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.append(container);
+  });
+
+  afterEach(() => {
+    ReactDOM.unmountComponentAtNode(container);
+    container.remove();
+    container = undefined;
+  });
+
+  test("useRoute: should match the correct route", () => {
+    function App() {
+      const route = useRoute(routesToMatch);
+
+      if (route === undefined) {
+        return <div> Not found </div>;
+      }
+
+      return (
+        <>
+          {route.name === "home" ? (
+            <div> Home </div>
+          ) : route.name === "profile" ? (
+            <div> Profile {route.params.username} </div>
+          ) : null}
+        </>
+      );
+    }
+
+    act(() => {
+      ReactDOM.render(<App />, container);
+    });
+
+    expect(container.textContent).toContain("Home");
+
+    act(() => {
+      unsafeNavigate("/profile/Zoontek");
+    });
+
+    expect(container.textContent).toContain("Profile Zoontek");
+
+    act(() => {
+      unsafeNavigate("/unknown");
+    });
+
+    expect(container.textContent).toContain("Not found");
+  });
+
+  test("useRouteFocus: should focus the correct element", () => {
+    function App() {
+      const route = useRoute(routesToMatch);
+      const containerRef = React.useRef(null);
+
+      useRouteFocus({
+        containerRef,
+        route,
+      });
+
+      if (route === undefined) {
+        return <div> Not found </div>;
+      }
+
+      return (
+        <div ref={containerRef} data-test-id="routeContainer">
+          {route.name === "home" ? (
+            <div> Home </div>
+          ) : route.name === "profile" ? (
+            <div> Profile {route.params.username} </div>
+          ) : null}
+        </div>
+      );
+    }
+
+    act(() => {
+      ReactDOM.render(<App />, container);
+    });
+
+    // doesn't take focus initially
+    expect(document.activeElement).toBe(document.body);
+
+    act(() => {
+      unsafeNavigate("/profile/Zoontek");
+    });
+
+    // takes focus after a route change
+    expect(document.activeElement).toBe(
+      document.querySelector("[data-test-id='routeContainer']"),
+    );
+
+    // doesn't switch focus if route remains the same
+    document.body.setAttribute("tabIndex", "-1");
+    document.body.focus();
+    expect(document.activeElement).toBe(document.body);
+    act(() => {
+      unsafeNavigate("/profile/Zoontek");
+    });
+    expect(document.activeElement).toBe(document.body);
+
+    act(() => {
+      unsafeNavigate("/profile/bloodyowl");
+    });
+    // takes focus when only a param changes
+    expect(document.activeElement).toBe(
+      document.querySelector("[data-test-id='routeContainer']"),
+    );
+  });
+});

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,6 +1,7 @@
+import * as React from "react";
 import { match } from "ts-pattern";
 import { Link } from "./Link";
-import { createURL, useRoute } from "./router";
+import { createURL, useRoute, useRouteFocus } from "./router";
 
 const EXAMPLE_DATA: Record<string, string[]> = {
   zoontek: [
@@ -29,6 +30,13 @@ const EXAMPLE_DATA: Record<string, string[]> = {
 export const App = () => {
   const route = useRoute(["root", "users", "user", "repositoriesArea"]);
 
+  const containerRef = React.useRef(null);
+
+  useRouteFocus({
+    containerRef,
+    route,
+  });
+
   return (
     <div style={{ display: "flex" }}>
       <nav
@@ -43,7 +51,10 @@ export const App = () => {
         <Link to={createURL("users")}>Users</Link>
       </nav>
 
-      <main style={{ display: "flex", flexDirection: "column" }}>
+      <main
+        ref={containerRef}
+        style={{ display: "flex", flexDirection: "column" }}
+      >
         {match(route)
           .with({ name: "root" }, () => <h1>Homepage</h1>)
           .with({ name: "users" }, () => (
@@ -79,33 +90,40 @@ export const App = () => {
 
 const Repositories = ({ userId }: { userId: string }) => {
   const route = useRoute(["repositories", "repository"]);
+  const containerRef = React.useRef(null);
+
+  useRouteFocus({
+    containerRef,
+    route,
+  });
 
   return (
     <>
       <h1>{userId} repositories</h1>
-
-      {match(route)
-        .with({ name: "repositories" }, () => (
-          <ul>
-            {EXAMPLE_DATA[userId]?.map((repositoryId) => (
-              <li key={repositoryId}>
-                <Link to={createURL("repository", { userId, repositoryId })}>
-                  {repositoryId}
-                </Link>
-              </li>
-            ))}
-          </ul>
-        ))
-        .with(
-          { name: "repository" },
-          ({ params: { userId, repositoryId } }) => (
-            <h2>
-              {userId}/{repositoryId}
-            </h2>
-          ),
-        )
-        .with(undefined, () => <div>404 - Repository not found</div>)
-        .exhaustive()}
+      <div ref={containerRef}>
+        {match(route)
+          .with({ name: "repositories" }, () => (
+            <ul>
+              {EXAMPLE_DATA[userId]?.map((repositoryId) => (
+                <li key={repositoryId}>
+                  <Link to={createURL("repository", { userId, repositoryId })}>
+                    {repositoryId}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          ))
+          .with(
+            { name: "repository" },
+            ({ params: { userId, repositoryId } }) => (
+              <h2>
+                {userId}/{repositoryId}
+              </h2>
+            ),
+          )
+          .with(undefined, () => <div>404 - Repository not found</div>)
+          .exhaustive()}
+      </div>
     </>
   );
 };

--- a/example/src/router.ts
+++ b/example/src/router.ts
@@ -13,6 +13,7 @@ export const {
   useLocation,
   useRoute,
   useBlocker,
+  useRouteFocus,
   getLocation,
 } = createRouter({
   root: "/",
@@ -21,8 +22,4 @@ export const {
   repositoriesArea: "/users/:userId/repositories/*",
   repositories: "/users/:userId/repositories",
   repository: "/users/:userId/repositories/:repositoryId",
-});
-
-subscribe(() => {
-  console.log(getLocation());
 });

--- a/example/src/router.ts
+++ b/example/src/router.ts
@@ -13,6 +13,7 @@ export const {
   useLocation,
   useRoute,
   useBlocker,
+  getLocation,
 } = createRouter({
   root: "/",
   users: "/users",
@@ -20,4 +21,8 @@ export const {
   repositoriesArea: "/users/:userId/repositories/*",
   repositories: "/users/:userId/repositories",
   repository: "/users/:userId/repositories/:repositoryId",
+});
+
+subscribe(() => {
+  console.log(getLocation());
 });

--- a/src/history.ts
+++ b/src/history.ts
@@ -20,9 +20,12 @@ if (currentLocation.url !== createPath(history.location)) {
   history.replace(currentLocation.url); // URL cleanup
 }
 
+let locationHasChanged = false;
+
 history.listen(({ location }) => {
   const nextLocation = decodeLocation(location, false);
   if (!areLocationsEqual(nextLocation, currentLocation)) {
+    locationHasChanged = true;
     currentLocation = nextLocation;
     subscriptions.forEach((subscription) => subscription(currentLocation));
   }
@@ -45,3 +48,7 @@ export const useLocation = (): Location => {
 
 export { createPath as createPath };
 export { parsePath as parsePath };
+
+export const hasLocationChanged = () => {
+  return locationHasChanged;
+};

--- a/src/history.ts
+++ b/src/history.ts
@@ -1,0 +1,47 @@
+/**
+ * This module makes the different routes created with react-chicane listen to the same history instance
+ */
+import { createBrowserHistory, createPath, parsePath } from "history";
+import * as React from "react";
+import { useSubscription } from "use-subscription";
+import { areLocationsEqual, decodeLocation } from "./location";
+import { Location, Subscription } from "./types";
+const subscriptions = new Set<Subscription>();
+
+export const history = createBrowserHistory();
+
+let currentLocation = decodeLocation(history.location, true);
+
+export const getCurrentLocation = () => {
+  return currentLocation;
+};
+
+if (currentLocation.url !== createPath(history.location)) {
+  history.replace(currentLocation.url); // URL cleanup
+}
+
+history.listen(({ location }) => {
+  const nextLocation = decodeLocation(location, false);
+  if (!areLocationsEqual(nextLocation, currentLocation)) {
+    currentLocation = nextLocation;
+    subscriptions.forEach((subscription) => subscription(currentLocation));
+  }
+});
+
+export const subscribe = (subscription: Subscription): (() => void) => {
+  subscriptions.add(subscription);
+  return () => {
+    subscriptions.delete(subscription);
+  };
+};
+
+export const useLocation = (): Location => {
+  const subscription = React.useMemo(
+    () => ({ getCurrentValue: () => currentLocation, subscribe }),
+    [],
+  );
+  return useSubscription(subscription);
+};
+
+export { createPath as createPath };
+export { parsePath as parsePath };

--- a/src/history.ts
+++ b/src/history.ts
@@ -49,6 +49,11 @@ export const useLocation = (): Location => {
 export { createPath as createPath };
 export { parsePath as parsePath };
 
+// For testing purposes
+export const resetHasLocationChanged = () => {
+  locationHasChanged = false;
+};
+
 export const hasLocationChanged = () => {
   return locationHasChanged;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -191,9 +191,7 @@ export const createRouter = <
   let unsubscribeToLocationChange: (() => void) | undefined;
   unsubscribeToLocationChange = subscribe(() => {
     hasChangedLocation = true;
-    if (typeof unsubscribeToLocationChange == "function") {
-      unsubscribeToLocationChange();
-    }
+    unsubscribeToLocationChange?.();
     unsubscribeToLocationChange = undefined;
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { first } from "./helpers";
 import {
   createPath,
   getCurrentLocation,
+  hasLocationChanged,
   history,
   parsePath,
   subscribe,
@@ -186,19 +187,10 @@ export const createRouter = <
     containerRef: React.RefObject<unknown>;
   };
 
-  let hasChangedLocation = false;
-
-  let unsubscribeToLocationChange: (() => void) | undefined;
-  unsubscribeToLocationChange = subscribe(() => {
-    hasChangedLocation = true;
-    unsubscribeToLocationChange?.();
-    unsubscribeToLocationChange = undefined;
-  });
-
   const useRouteFocus = ({ route, containerRef }: RouteFocusProps) => {
     React.useEffect(() => {
       const element = containerRef.current as HTMLElement | undefined;
-      if (element && hasChangedLocation) {
+      if (element && hasLocationChanged()) {
         try {
           const name = element.nodeName;
           // A tabIndex of -1 allows element to be programmatically focused but

--- a/src/index.ts
+++ b/src/index.ts
@@ -190,6 +190,8 @@ export const createRouter = <
   const useRouteFocus = ({ route, containerRef }: RouteFocusProps) => {
     React.useEffect(() => {
       const element = containerRef.current as HTMLElement | undefined;
+      // Only focus after a history change for UX, so that areas outside routing (e.g. navigation header)
+      // are available immediately to keyboard navigation
       if (element && hasLocationChanged()) {
         try {
           const name = element.nodeName;

--- a/src/location.ts
+++ b/src/location.ts
@@ -34,3 +34,8 @@ export const decodeLocation = (
     }),
   };
 };
+
+// As the `encodeSearch` function guarantees a stable sorting, we can rely on a simple URL comparison
+export const areLocationsEqual = (a: Location, b: Location) => {
+  return a.url === b.url;
+};

--- a/src/matcher.ts
+++ b/src/matcher.ts
@@ -134,6 +134,22 @@ export const extractLocationParams = (
   return params;
 };
 
+export const matchAll = (
+  location: Location,
+  matchers: Matcher[],
+): { name: string; params: Params }[] => {
+  const routes = [];
+  for (const matcher of matchers) {
+    const params = extractLocationParams(location, matcher);
+
+    if (params != null) {
+      routes.push({ name: matcher.name, params });
+    }
+  }
+
+  return routes;
+};
+
 export const match = (
   location: Location,
   matchers: Matcher[],


### PR DESCRIPTION
# Summary

Groundwork for further updates:

- Compare `location` objects using their stable URL form to prevent extraneous subscriber calls
- Use a shared `history` instance called through a `useLocation` hook for all hooks relying on it
- Removed the `JSON.stringify`/`JSON.parse` bit as location is a more stable object
- Replace the `get location` by a `getLocation` function for DX (breaking change ⚠️)

- [x] I added the documentation in `README.md`
- [x] I added a sample use of the API in the example project (`example/`)
